### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "css-cursors",
-  "style": "cursors.css",
+  "style": "css/css-cursors.min.css",
+  "main": "css/css-cursors.css",
   "version": "1.0.8",
   "homepage": "http://github.com/mrmrs/css-cursors",
   "description": "Css module of single purpose classes for cursors",


### PR DESCRIPTION
When I try to import css-cursors into my Application.scss and build using webpack, babel I get compilation errors.
```
@import "~css-cursors";
```
```
    ERROR in ./node_modules/css-loader??ref--5-2!./node_modules/postcss-loader/lib??ref--5-3!./node_modules/resolve-url-loader!./node_modules/sass-loader/lib/loader.js??ref--5-5!./app/javascript/packs/Application.scss
    @import "~css-cursors";
    ^
          File to import not found or unreadable: ~css-cursors.
```

If I add the path to the css it works: 
```
@import "~css-cursors/css/css-cursors";
```
If I correct the paths in the package.json to point to the css files my build works without me having to hard code a path to the css.
```
@import "~css-cursors"; // this works with the updated package.json
```